### PR TITLE
adds a TypeScript Rug event handler to a Rug project

### DIFF
--- a/.atomist.yml
+++ b/.atomist.yml
@@ -15,3 +15,20 @@ generator:
     - "description": "PMD and CheckStyle code analysis"
     - "version": "0.1.0"
 
+---
+kind: "operation"
+client: "atomist-bot"
+editor:
+  name: "AddTypeScriptEventHandler"
+  group: "atomist"
+  artifact: "rug-rugs"
+  version: "0.29.0"
+  origin:
+    repo: "https://github.com/atomist/rug-rugs.git"
+    branch: "0f425945c62957ccc2ccb63e9980e6f78b97a4a1"
+    sha: "0f42594"
+  parameters:
+    - "handlerName": "CodeReviewOnPush"
+    - "description": "Run code analysis"
+    - "pathExpression": "/Tag()"
+

--- a/.atomist/handlers/event/CodeReviewOnPush.ts
+++ b/.atomist/handlers/event/CodeReviewOnPush.ts
@@ -1,0 +1,20 @@
+import { EventHandler, Tags } from "@atomist/rug/operations/Decorators";
+import { ChannelAddress, DirectedMessage, EventPlan, HandleEvent } from "@atomist/rug/operations/Handlers";
+import { Match } from "@atomist/rug/tree/PathExpression";
+
+import { Tag } from "@atomist/cortex/Tag";
+
+/**
+ * A Run code analysis.
+ */
+@EventHandler("CodeReviewOnPush", "Run code analysis", "/Tag()")
+@Tags("documentation")
+export class CodeReviewOnPush implements HandleEvent<Tag, Tag> {
+    public handle(event: Match<Tag, Tag>): EventPlan {
+        const root: Tag = event.root;
+        const message = new DirectedMessage(`${root.nodeName()} event received`, new ChannelAddress("#general"));
+        return EventPlan.ofMessage(message);
+    }
+}
+
+export const codeReviewOnPush = new CodeReviewOnPush();

--- a/.atomist/tests/handlers/event/CodeReviewOnPushSteps.ts
+++ b/.atomist/tests/handlers/event/CodeReviewOnPushSteps.ts
@@ -1,0 +1,20 @@
+import { DirectedMessage } from "@atomist/rug/operations/Handlers";
+import { EventHandlerScenarioWorld, Given, Then, When } from "@atomist/rug/test/handler/Core";
+
+import { Tag } from "@atomist/cortex/stub/Tag";
+
+Given("the CodeReviewOnPush is registered", (w: EventHandlerScenarioWorld) => {
+    w.registerHandler("CodeReviewOnPush");
+});
+
+When("a new Tag is received", (w: EventHandlerScenarioWorld) => {
+    const event = new Tag();
+    w.sendEvent(event);
+});
+
+Then("the CodeReviewOnPush event handler should respond with the correct message",
+    (w: EventHandlerScenarioWorld) => {
+        const expected = `Tag event received`;
+        const message = (w.plan().messages[0] as DirectedMessage).body;
+        return message === expected;
+    });

--- a/.atomist/tests/handlers/event/CodeReviewOnPushTest.feature
+++ b/.atomist/tests/handlers/event/CodeReviewOnPushTest.feature
@@ -1,0 +1,9 @@
+Feature: CodeReviewOnPush handler handles events
+  The CodeReviewOnPush event handler should
+  respond with the appropriate message.
+  This is a sample test.
+
+  Scenario: Executing a sample event handler
+    Given the CodeReviewOnPush is registered
+    When a new Tag is received
+    Then the CodeReviewOnPush event handler should respond with the correct message


### PR DESCRIPTION
Created by Atomist Editor `AddTypeScriptEventHandler`
```
---
kind: "operation"
client: "atomist-bot"
editor:
  name: "AddTypeScriptEventHandler"
  group: "atomist"
  artifact: "rug-rugs"
  version: "0.29.0"
  origin:
    repo: "https://github.com/atomist/rug-rugs.git"
    branch: "0f425945c62957ccc2ccb63e9980e6f78b97a4a1"
    sha: "0f42594"
  parameters:
    - "handlerName": "CodeReviewOnPush"
    - "description": "Run code analysis"
    - "pathExpression": "/Tag()"

```